### PR TITLE
add xterm related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 0.0.7 _Mar.09.2024_
+   * improve [support for xterm](https://github.com/iambumblehead/render-thumb-for.sh/pull/25)
  * 0.0.6 _Mar.07.2024_
    * added sixel and kitty [differentiation to README](https://github.com/iambumblehead/render-thumb-for.sh/pull/16)
    * added [sixel detection](https://github.com/iambumblehead/render-thumb-for.sh/pull/17)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ render-thumb-for.sh /path/to/book.epub
 <dl>
   <dt>Which terminal emulators will render images?</dt>
   <dd>`iTerm2`, `kitty` and `foot` can render images with this script. Sixel support for other terminals is listed here https://www.arewesixelyet.com/</dd>
-  <dd>`xterm` is not supported, but can be configured to work with this script. Please see https://github.com/iambumblehead/render-thumb-for.sh/pull/25</dd>
+  <dd>`xterm` can be configured, see https://github.com/iambumblehead/render-thumb-for.sh/wiki#with-xterm</dd>
   <dt>Anything else?</dt>
   <dd>Suggestions and improvements are welcome and appreciated. `render-thumb-for.sh` may feel "slow" as it presently does not yet cache or reuse preview images it generates.</dd>
 </dl>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ render-thumb-for.sh /path/to/book.epub
 <dl>
   <dt>Which terminal emulators will render images?</dt>
   <dd>`iTerm2`, `kitty` and `foot` can render images with this script. Sixel support for other terminals is listed here https://www.arewesixelyet.com/</dd>
+  <dd>`xterm` is not supported, but can be configured to work with this script. Please see https://github.com/iambumblehead/render-thumb-for.sh/pull/25</dd>
   <dt>Anything else?</dt>
   <dd>Suggestions and improvements are welcome and appreciated. `render-thumb-for.sh` may feel "slow" as it presently does not yet cache or reuse preview images it generates.</dd>
 </dl>

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -221,7 +221,7 @@ wh_scaled_get () {
 #  The default is "1000x1000" (given as width by height).
 wh_term_xterm_max_get () {
     if [[ -n $maxGraphicSize ]] && [[ $maxGraphicSize =~ $wxhstr_re ]]; then
-        echo "${maxGraphicSize/x/0 }"
+        echo "${maxGraphicSize/x/ }"
     else
         echo "1000 1000"
     fi

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -30,7 +30,7 @@ resolution_re="([[:digit:]]{2,8}[x][[:digit:]]{2,8})"
 fullpathattr_re="full-path=['\"]([^'\"]*)['\"]"
 contentattr_re="content=['\"]([^'\"]*)['\"]"
 hrefattr_re="href=['\"]([^'\"]*)['\"]"
-#wxhstr_re="^[[:digit:]]*[x][[:digit:]]*$"
+wxhstr_re="^[[:digit:]]*[x][[:digit:]]*$"
 
 cachedir="$HOME/.config/render-thumb-for"
 if [ -n "${XDG_CONFIG_HOME}" ]; then
@@ -219,9 +219,17 @@ wh_scaled_get () {
 #  displayed.
 #
 #  The default is "1000x1000" (given as width by height).
+wh_term_xterm_max_get () {
+    if [[ -n $maxGraphicSize ]] && [[ $maxGraphicSize =~ $wxhstr_re ]]; then
+        echo "${maxGraphicSize/x/0 }"
+    else
+        echo "1000 1000"
+    fi
+}
+
 wh_term_scaled_get () {
     if [[ $TERM =~ xterm ]]; then
-        wh_scaled_get "$1" "1000 1000"
+        wh_scaled_get "$1" "$(wh_term_xterm_max_get)"
     else
         echo "$1"
     fi

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -168,7 +168,6 @@ wh_start_get () {
     [[ -z "$w" ]] && w="1000"
     [[ -z "$h" ]] && h="$w"
 
-    
     echo "$((${w} * ${w_mul})) $((${h} * ${h_mul}))"
 }
 
@@ -210,6 +209,22 @@ wh_scaled_get () {
     fi
 
     echo "$fin_w $fin_h"
+}
+
+# https://man.freebsd.org/cgi/man.cgi?query=xterm
+#
+# maxGraphicSize (class MaxGraphicSize)
+#  If xterm is configured to support ReGIS or SIXEL graphics, this
+#  resource controls the maximum size  of a graph which	can be
+#  displayed.
+#
+#  The default is "1000x1000" (given as width by height).
+wh_term_scaled_get () {
+    if [[ $TERM =~ xterm ]]; then
+        echo $(wh_scaled_get "$1" "1000 1000")
+    else
+        echo "$1"
+    fi
 }
 
 img_wh_exiftool_get () {  # shellcheck disable=SC2016
@@ -472,6 +487,7 @@ show_font () {
 start () {
     path=$1
     start_wh=$(wh_start_get "$2" "$3" "$4" "$5")
+    start_wh=$(wh_term_scaled_get "$start_wh")
 
     if [ -n "$cache" ]; then
         cachedir_calibrate "$cachedir"

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -221,7 +221,7 @@ wh_scaled_get () {
 #  The default is "1000x1000" (given as width by height).
 wh_term_scaled_get () {
     if [[ $TERM =~ xterm ]]; then
-        "$(wh_scaled_get "$1" "1000 1000")"
+        wh_scaled_get "$1" "1000 1000"
     else
         echo "$1"
     fi

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -145,6 +145,8 @@ paint () {
         # kitten does not provide a 'geometry' option
         # so image must have been preprocessed to fit desired geometry
         kitten icat --align left "$img_path"
+    else
+        echo "image display is not supported"
     fi
 }
 

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -221,7 +221,7 @@ wh_scaled_get () {
 #  The default is "1000x1000" (given as width by height).
 wh_term_scaled_get () {
     if [[ $TERM =~ xterm ]]; then
-        echo $(wh_scaled_get "$1" "1000 1000")
+        echo "$(wh_scaled_get "$1" "1000 1000")"
     else
         echo "$1"
     fi

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -221,7 +221,7 @@ wh_scaled_get () {
 #  The default is "1000x1000" (given as width by height).
 wh_term_scaled_get () {
     if [[ $TERM =~ xterm ]]; then
-        echo "$(wh_scaled_get "$1" "1000 1000")"
+        "$(wh_scaled_get "$1" "1000 1000")"
     else
         echo "$1"
     fi


### PR DESCRIPTION
This branch attempts to troubleshoot and address issues affecting xterm per discussion here https://github.com/vifm/vifm/issues/419#issuecomment-1986966958

I don't have too much bandwidth today, but wanted to at least start this branch

From wayland Gnome, xterm must be started indirectly using two separate terminal processes, the resulting windows have no decorations and are not resizable or repositionable.
```bash
Xwayland :7
```

```bash
DISPLAY=:7 xterm -xrm "XTerm*decTerminalID: vt340" -xrm "XTerm*numColorRegisters: 256"
```

cc @Mange @xaizek 