### PR TITLE
Add support for cells column row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  * 0.0.7 _Mar.09.2024_
    * improve [support for xterm](https://github.com/iambumblehead/render-thumb-for.sh/pull/25)
    * addded [support for cell units](https://github.com/iambumblehead/render-thumb-for.sh/pull/26)
+   * migrate [from convert command to magick](https://github.com/iambumblehead/render-thumb-for.sh/pull/26), per [advice here](https://github.com/ImageMagick/ImageMagick/discussions/7168)
  * 0.0.6 _Mar.07.2024_
    * added sixel and kitty [differentiation to README](https://github.com/iambumblehead/render-thumb-for.sh/pull/16)
    * added [sixel detection](https://github.com/iambumblehead/render-thumb-for.sh/pull/17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
  * 0.0.7 _Mar.09.2024_
    * improve [support for xterm](https://github.com/iambumblehead/render-thumb-for.sh/pull/25)
-   * addded [support for cell units](https://github.com/iambumblehead/render-thumb-for.sh/pull/26)
+   * added [support for cell units](https://github.com/iambumblehead/render-thumb-for.sh/pull/26)
    * migrate [from convert command to magick](https://github.com/iambumblehead/render-thumb-for.sh/pull/26), per [advice here](https://github.com/ImageMagick/ImageMagick/discussions/7168)
+   * support [pdf images with imagemagick](https://github.com/iambumblehead/render-thumb-for.sh/pull/26)
  * 0.0.6 _Mar.07.2024_
    * added sixel and kitty [differentiation to README](https://github.com/iambumblehead/render-thumb-for.sh/pull/16)
    * added [sixel detection](https://github.com/iambumblehead/render-thumb-for.sh/pull/17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  * 0.0.7 _Mar.09.2024_
    * improve [support for xterm](https://github.com/iambumblehead/render-thumb-for.sh/pull/25)
+   * addded [support for cell units](https://github.com/iambumblehead/render-thumb-for.sh/pull/26)
  * 0.0.6 _Mar.07.2024_
    * added sixel and kitty [differentiation to README](https://github.com/iambumblehead/render-thumb-for.sh/pull/16)
    * added [sixel detection](https://github.com/iambumblehead/render-thumb-for.sh/pull/17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
  * 0.0.7 _Mar.09.2024_
    * improve [support for xterm](https://github.com/iambumblehead/render-thumb-for.sh/pull/25)
    * added [support for cell units](https://github.com/iambumblehead/render-thumb-for.sh/pull/26)
-   * migrate [from convert command to magick](https://github.com/iambumblehead/render-thumb-for.sh/pull/26), per [advice here](https://github.com/ImageMagick/ImageMagick/discussions/7168)
+   * migrate [from convert command to magick](https://github.com/iambumblehead/render-thumb-for.sh/pull/26), per [advice here](https://github.com/ImageMagick/ImageMagick/discussions/7168) (maybe both 'convert' and 'magick' should be supported?)
    * support [pdf images with imagemagick](https://github.com/iambumblehead/render-thumb-for.sh/pull/26)
+   * added [support for zoom param, eg -z 3](https://github.com/iambumblehead/render-thumb-for.sh/pull/26), used for foot <= 1.16.2, see [link](https://codeberg.org/dnkl/foot/issues/1643)
  * 0.0.6 _Mar.07.2024_
    * added sixel and kitty [differentiation to README](https://github.com/iambumblehead/render-thumb-for.sh/pull/16)
    * added [sixel detection](https://github.com/iambumblehead/render-thumb-for.sh/pull/17)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <a href="https://github.com/iambumblehead/render-thumb-for.sh/releases"><img src="https://img.shields.io/github/release/iambumblehead/render-thumb-for.sh.svg"></a>
 </p>
 
-**render-thumb-for.sh renders images for various file types to the terminal.** It renders images from audio, font, video, pdf, epub, svg and other files --supporting both kitty and sixel formats. It detects available commands from the system and for a small dependency tree,
+**render-thumb-for.sh renders images for various file types to the terminal.** It renders images from audio, font, video, pdf, epub, svg and other files --supporting both kitty and sixel formats. It detects available commands from the system for a small dependency tree,
  * `magick` sixel or `kitten icat` display,
  * `mutool`, `pdftoppm` or `magick` pdf,
  * `ffmpeg` video audio,

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 </p>
 
 **render-thumb-for.sh renders images for various file types to the terminal.** It renders images from audio, font, video, pdf, epub, svg and other files --supporting both kitty and sixel formats. It detects available commands from the system and for a small dependency tree,
- * render images: `magick` (sixel) or `kitten icat` (kitty),
- * convert pdf: `mutool` or `pdftoppm` or `magick`
- * convert video and audio: `ffmpeg`
- * convert font: `magick`
- * probe epub documents: `unzip`
- * probe file properties: `exiftool` or `identify`
+ * `magick` sixel or `kitten icat` display,
+ * `mutool`, `pdftoppm` or `magick` pdf,
+ * `ffmpeg` video audio,
+ * `magick` font,
+ * `unzip` epub,
+ * `exiftool` or `identify` file type
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 <h3 align="center"><img src="./test/render-for.demo.gif" alt="demo" height="400px"></h3>
-<p align="center"><code>render-thumb-for.sh</code> renders preview images to the terminal; ~500 LOC bash</p>
+<p align="center"><code>render-thumb-for.sh</code> renders preview images to the terminal; ~800 LOC bash</p>
 <p align="center">
 <a href="https://github.com/iambumblehead/render-thumb-for.sh/workflows"><img src="https://github.com/iambumblehead/render-thumb-for.sh/workflows/shellcheck/badge.svg"></a>
 <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-ISC-blue.svg"></a>
 <a href="https://github.com/iambumblehead/render-thumb-for.sh/releases"><img src="https://img.shields.io/github/release/iambumblehead/render-thumb-for.sh.svg"></a>
 </p>
 
-**render-thumb-for.sh renders images for various file types to the terminal.** It renders images from audio, font, video, pdf, epub, svg and other files --supporting both kitty and sixel formats. It detects available commands from the system and has a small dependency tree,
- * `imagemagick` (sixel) or `kitten icat` (kitty),
- * `ffmpeg` (video, audio),
- * `unzip` (epub),
- * `pdftoppm` or `mutool` (pdf),
- * `exiftool` or `identify` (probe file properties).
+**render-thumb-for.sh renders images for various file types to the terminal.** It renders images from audio, font, video, pdf, epub, svg and other files --supporting both kitty and sixel formats. It detects available commands from the system and for a small dependency tree,
+ * render images: `magick` (sixel) or `kitten icat` (kitty),
+ * convert pdf: `mutool` or `pdftoppm` or `magick`
+ * convert video and audio: `ffmpeg`
+ * convert font: `magick`
+ * probe epub documents: `unzip`
+ * probe file properties: `exiftool` or `identify`
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 <a href="https://github.com/iambumblehead/render-thumb-for.sh/releases"><img src="https://img.shields.io/github/release/iambumblehead/render-thumb-for.sh.svg"></a>
 </p>
 
+> [!WARNING]
+> This project has no major releases and sources will change suddenly any time. No unit tests at this time.
+
 **render-thumb-for.sh renders images for various file types to the terminal.** It renders images from audio, font, video, pdf, epub, svg and other files --supporting both kitty and sixel formats. It detects available commands from the system for a small dependency tree,
  * `magick` sixel or `kitten icat` display,
  * `mutool`, `pdftoppm` or `magick` pdf,

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -52,31 +52,6 @@ if [ -n "${XDG_CONFIG_HOME}" ]; then
     cachedir="$XDG_CONFIG_HOME/render-thumb-for"
 fi
 
-# thank you @topcat001
-# https://github.com/orgs/tmux/discussions/3565#discussioncomment-8713254
-escquery_sixel_issupport_get () {
-    esc="$escXTERMsixelissupported"
-    if [[ -n nested ]]; then
-        echo -e "$esc" > /dev/tty
-        IFS=";" read -d "c" -sra REPLY < /dev/tty
-        for code in "${REPLY[@]}"; do
-            if [[ $code == 4 ]]; then
-                printf '%s\n' "true"
-                exit 1
-            fi
-        done
-    fi
-
-    IFS=";" read -d "c" -sra REPLY -p "$esc" >&2
-    for code in "${REPLY[@]}"; do
-        if [[ $code == 4 ]]; then
-            printf '%s\n' "true"
-            exit 1
-        fi
-    done
-}
-is_sixel_support=$(escquery_sixel_issupport_get)
-
 cells=
 nested=
 cache="true" # getopts hcm: would force 'm' to have params
@@ -97,6 +72,31 @@ while getopts "cnsth" opt; do
     esac
 done
 shift $(($OPTIND - 1))
+
+# thank you @topcat001
+# https://github.com/orgs/tmux/discussions/3565#discussioncomment-8713254
+escquery_sixel_issupport_get () {
+    esc="$escXTERMsixelissupported"
+    if [[ -n "$nested" ]]; then
+        echo -e "$esc" > /dev/tty
+        IFS=";" read -d "c" -sra REPLY < /dev/tty
+        for code in "${REPLY[@]}"; do
+            if [[ $code == 4 ]]; then
+                printf '%s\n' "true"
+                exit 1
+            fi
+        done
+    fi
+
+    IFS=";" read -d "c" -sra REPLY -p "$esc" >&2
+    for code in "${REPLY[@]}"; do
+        if [[ $code == 4 ]]; then
+            printf '%s\n' "true"
+            exit 1
+        fi
+    done
+}
+is_sixel_support=$(escquery_sixel_issupport_get)
 
 regex() {
     # Usage: regex "string" "regex"
@@ -258,7 +258,7 @@ wh_term_columnsrows_get () {
 
 wh_term_resolution_get () {
     esc="$escXTERMtermsize"
-    if [[ -n nested ]]; then
+    if [[ -n "$nested" ]]; then
         echo -e "$esc" > /dev/tty
         IFS=";" read -d t -sra REPLY -t "$timeoutss" < /dev/tty
         if [[ "${REPLY[1]}" =~ $number_re ]]; then
@@ -274,7 +274,7 @@ wh_term_resolution_get () {
     fi
 
     esc="$escXTERMtermsizeTMUX"
-    if [[ -n nested ]]; then
+    if [[ -n "$nested" ]]; then
         echo -e '\e[14t' > /dev/tty
         IFS=$';\t' read -d t -sra REPLY -t "$timeoutss" < /dev/tty
         if [[ "${REPLY[1]}" =~ $number_re ]]; then

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -233,7 +233,7 @@ wh_term_rowscolumns_get () {
 wh_term_resolution_get () {
     # Usage: wh_term_resolution_get
     cmd=$(printf '%b' "${TMUX:+\\ePtmux;\\e}\\e[14t${TMUX:+\\e\\\\}")
-    IFS=";t" read -d "t" -sra term_size -t "$timeoutss" -p $cmd >&2
+    IFS=$";\t" read -d t -sra term_size -t "$timeoutss" -p $cmd >&2
     printf '%s\n' "${term_size[1]} ${term_size[2]}"
 }
 

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -31,7 +31,7 @@ mimeTypePDF="pdf"
 #   https://github.com/dylanaraps/pure-bash-bible
 #     ?tab=readme-ov-file#get-the-terminal-size-in-pixels
 escXTERMsixelissupported=$(printf '%b' "\e[c")
-escXTERMtermsize=$(printf '%b' "\e[14;2t")
+escXTERMtermsize=$(printf '%b' "\e[14t")
 #escXTERMcellsize=$(printf '%b' "\e[16t")
 escXTERMtermsizeTMUX=$(printf '%b' "${TMUX:+\\ePtmux;\\e}\\e[14t${TMUX:+\\e\\\\}")
 

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -56,7 +56,7 @@ cells=
 cache="true" # getopts hcm: would force 'm' to have params
 timeoutss=1.2
 defaultw=1000
-while getopts "phc" opt; do
+while getopts "csth" opt; do
     case "${opt}" in
         c) cells="true";; # use cell dimensions
         s) cache="true";; # use a cache
@@ -229,6 +229,7 @@ wh_term_rowscolumns_get () {
 
 # https://github.com/dylanaraps/pure-bash-bible
 #  ?tab=readme-ov-file#get-the-terminal-size-in-pixels
+# shellcheck disable=SC2154
 wh_term_resolution_get () {
     # Usage: wh_term_resolution_get
     cmd=$(printf '%b' "${TMUX:+\\ePtmux;\\e}\\e[14t${TMUX:+\\e\\\\}")

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -271,13 +271,15 @@ wh_fromrowscols_get () {
     IFS=" " read -r -a termcr <<< "$(wh_term_columnsrows_get)"
 
     if [[ -n "$colw" ]]; then
-        pixelw=$(((((${termwh[0]} * 100) / ${termcr[0]} * $colw) / 100)))
+        # shellcheck disable=SC2323
+        pixelw=$((((((${termwh[0]} * 100) / ${termcr[0]}) * $colw) / 100)))
     else
         pixelw="$defaultw"
     fi
 
     if [[ -n "$rowh" ]]; then
-        pixelh=$(((((${termwh[1]} * 100) / ${termcr[1]} * $rowh) / 100)))
+        # shellcheck disable=SC2323
+        pixelh=$((((((${termwh[1]} * 100) / ${termcr[1]}) * $rowh) / 100)))
     else
         pixelh="$pixelw"
     fi    

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -233,7 +233,7 @@ wh_term_rowscolumns_get () {
 wh_term_resolution_get () {
     # Usage: wh_term_resolution_get
     cmd=$(printf '%b' "${TMUX:+\\ePtmux;\\e}\\e[14t${TMUX:+\\e\\\\}")
-    IFS=$";\t" read -d t -sra term_size -t "$timeoutss" -p $cmd >&2
+    IFS=$';\t' read -d t -sra term_size -t "$timeoutss" -p $cmd >&2
     printf '%s\n' "${term_size[1]} ${term_size[2]}"
 }
 

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -11,7 +11,7 @@ is_cmd_kitten=$(command -v kitten)
     is_cmd_kitten_icat_support=$(kitten icat --detect-support 2>&1)
 is_cmd_mutool=$(command -v mutool)
 is_cmd_pdftoppm=$(command -v pdftoppm)
-is_cmd_convert=$(command -v convert)
+is_cmd_magick=$(command -v magick)
 is_cmd_exiftool=$(command -v exiftool)
 is_cmd_identify=$(command -v identify)
 is_cmd_ffmpeg=$(command -v ffmpeg)
@@ -170,11 +170,11 @@ paint () {
 
     if [[ -n "$is_sixel_support" ]]; then
         export MAGICK_OCL_DEVICE=true
-        convert \
-            -channel rgba \
+        magick \
             -background "rgba(0,0,0,0)" \
+            "$img_path" \
             -geometry "${img_wh/ /x}" \
-            "$img_path" sixel:-
+            sixel:-
 
         echo ""
     elif [[ -n "$is_cmd_kitten_icat_support" ]]; then
@@ -583,12 +583,12 @@ show_font () {
     font_preview_multiline=${font_preview_text// /\\n}
     font_thumb_path=$(cachedir_path_get "$cachedir" "font" "w h" ".jpg")
 
-    if [[ -z "$is_cmd_convert" ]]; then
+    if [[ -z "$is_cmd_magick" ]]; then
         echo "'convert' command not found (imagemagick)";
         exit 1
     fi
 
-    convert \
+    magick \
         -size "${font_wh_max/ /x}" \
         -background "$font_bg_color" \
         -fill "$font_fg_color" \

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -544,12 +544,7 @@ show_pdf () {
     pdf_wh_max=$2
     pdf_thumb_path=""
 
-    if [[ -z "$is_cmd_mutool" ]] && \
-           [[ -z "$is_cmd_pdftoppm" ]] && \
-               [[ -z "$is_cmd_magick" ]]; then
-        echo "'mutool', 'pdftoppm' or `magick` commands not found";
-        exit 1
-    elif [[ -n "$is_cmd_mutool" ]]; then
+    if [[ -n "$is_cmd_mutool" ]]; then
         pdf_thumb_path=$(cachedir_path_get "$cachedir" "pdf" "w h" ".png")
         mutool \
             draw -i -F png \
@@ -568,6 +563,9 @@ show_pdf () {
             "$pdf_thumb_path" \
             -define pdf:thumbnail=true \
             "$pdf_path"
+    else
+        echo "mutool, pdftoppm or magick commands not found";
+        exit 0
     fi
 
     paint "$pdf_thumb_path" "$pdf_wh_max"

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -55,8 +55,6 @@ fi
 # thank you @topcat001
 # https://github.com/orgs/tmux/discussions/3565#discussioncomment-8713254
 is_sixel_support_get () {
-    support=(0)
-
     IFS=";" read -r -a REPLY -s -d "c" -p "$escXTERMsixelissupported" >&2
     for code in "${REPLY[@]}"; do
         if [[ $code == 4 ]]; then
@@ -245,7 +243,7 @@ wh_term_columnsrows_get () {
 
 wh_term_resolution_get () {
     esc="$escXTERMtermsize"
-    IFS=";" read -d t -sa REPLY -t ${timeoutss} -p "$esc" >&2
+    IFS=";" read -d t -sra REPLY -t "$timeoutss" -p "$esc" >&2
     if [[ "${REPLY[1]}" =~ $number_re ]]; then
         printf '%s\n' "${REPLY[2]} ${REPLY[1]}"
         exit 0

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -244,8 +244,8 @@ wh_term_resolution_get () {
 wh_fromrowscols_get () {
     colw="$1"
     rowh="$2"
-    IFS=" " read -r -a termwh <<< $(wh_term_resolution_get)
-    IFS=" " read -r -a termrc <<< $(wh_term_rowscolumns_get)
+    IFS=" " read -r -a termwh <<< "$(wh_term_resolution_get)"
+    IFS=" " read -r -a termrc <<< "$(wh_term_rowscolumns_get)"
 
     if [[ -n "$colw" ]]; then
         # shellcheck disable=SC2323

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -54,20 +54,23 @@ fi
 
 cells=
 nested=
+zoom=1
 cache="true" # getopts hcm: would force 'm' to have params
 timeoutss=1.2
 defaultw=1000
-while getopts "cnsth" opt; do
+while getopts "cnstz:h" opt; do
     case "${opt}" in
         c) cells="true";; # use cell dimensions
         n) nested="true";; # nested in ncurses, send esc queries to tty
         s) cache="true";; # use a cache
         t) timeoutss="${OPTARG}";; # use custom timeout, eg 2.5
+        z) zoom="${OPTARG}";; # for foot <= 1.16.2, use custom zoom factor, eg 2
         h|*) # Display help.
-            echo "-c to use row and height as cell units"
-            echo "-n to declare ncurses nested, send escape queries to tty"
-            echo "-s to configure cache ex, -s true"
-            echo "-t to use custom timeout (seconds) w/ shell query functions"
+            echo "-c use row and height as cell units"
+            echo "-n declare ncurses nested, send escape queries to tty"
+            echo "-s configure cache ex, -s true"
+            echo "-t use custom timeout (seconds) w/ shell query functions"
+            echo "-z configure zoom. affects calculated view area size ex, 2"
             exit 0;;
     esac
 done
@@ -317,7 +320,7 @@ wh_fromrowscols_get () {
         pixelh="$pixelw"
     fi    
 
-    echo "$pixelw $pixelh"
+    echo "$(($pixelw * $zoom)) $(($pixelh * $zoom))"
 }
 
 # https://man.freebsd.org/cgi/man.cgi?query=xterm

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -545,8 +545,9 @@ show_pdf () {
     pdf_thumb_path=""
 
     if [[ -z "$is_cmd_mutool" ]] && \
-           [[ -z "$is_cmd_pdftoppm" ]]; then
-        echo "'mutool' or 'pdftoppm' commands not found";
+           [[ -z "$is_cmd_pdftoppm" ]] && \
+               [[ -z "$is_cmd_magick" ]]; then
+        echo "'mutool', 'pdftoppm' or `magick` commands not found";
         exit 1
     elif [[ -n "$is_cmd_mutool" ]]; then
         pdf_thumb_path=$(cachedir_path_get "$cachedir" "pdf" "w h" ".png")
@@ -561,6 +562,12 @@ show_pdf () {
             -f 1 -l 1 \
             -scale-to "$(wh_max_get "$2")" \
             -jpeg "$pdf_path" "${pdf_thumb_path%.*}"
+    elif [[ -n "$is_cmd_magick" ]]; then
+        pdf_thumb_path=$(cachedir_path_get "$cachedir" "pdf" "w h" ".jpg")
+        magick \
+            "$pdf_thumb_path" \
+            -define pdf:thumbnail=true \
+            "$pdf_path"
     fi
 
     paint "$pdf_thumb_path" "$pdf_wh_max"

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -221,7 +221,10 @@ wh_scaled_get () {
 # https://github.com/dylanaraps/pure-bash-bible
 #  ?tab=readme-ov-file#get-the-terminal-size-in-lines-and-columns-from-a-script
 wh_term_rowscolumns_get () {
-    stty size
+    # (:;:) is a micro sleep to ensure the variables are
+    # exported immediately.
+    shopt -s checkwinsize; (:;:)
+    printf '%s\n' "$(tput lines) $(tput cols) "
 }
 
 # https://github.com/dylanaraps/pure-bash-bible

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -233,7 +233,7 @@ wh_term_rowscolumns_get () {
 wh_term_resolution_get () {
     # Usage: wh_term_resolution_get
     cmd=$(printf '%b' "${TMUX:+\\ePtmux;\\e}\\e[14t${TMUX:+\\e\\\\}")
-    IFS=";t" read -d t -sra term_size -t 2 -p $cmd >&2
+    IFS=";t" read -d "t" -sra term_size -t "$timeoutss" -p $cmd >&2
     printf '%s\n' "${term_size[1]} ${term_size[2]}"
 }
 
@@ -242,18 +242,20 @@ wh_term_resolution_get () {
 # to avoid rounding issues that may result io too-small numbers,
 # resolution is calculated from the full set of columns and rows
 wh_fromrowscols_get () {
-    colw=$1
-    rowh=$2
+    colw="$1"
+    rowh="$2"
     IFS=" " read -r -a termwh <<< $(wh_term_resolution_get)
     IFS=" " read -r -a termrc <<< $(wh_term_rowscolumns_get)
 
     if [[ -n "$colw" ]]; then
+        # shellcheck disable=SC2323
         pixelw=$((((((${termwh[0]} * 100) / ${termrc[0]}) * $colw) / 100)))
     else
         pixelw="$defaultw"
     fi
 
     if [[ -n "$rowh" ]]; then
+        # shellcheck disable=SC2323
         pixelh=$((((((${termwh[1]} * 100) / ${termrc[1]}) * $rowh) / 100)))
     else
         pixelh="$pixelw"

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -233,7 +233,7 @@ wh_term_rowscolumns_get () {
 wh_term_resolution_get () {
     # Usage: wh_term_resolution_get
     cmd=$(printf '%b' "${TMUX:+\\ePtmux;\\e}\\e[14t${TMUX:+\\e\\\\}")
-    IFS=$';\t' read -d t -sra term_size -t "$timeoutss" -p $cmd >&2
+    IFS=$';\t' read -d t -sra term_size -t "$timeoutss" -p "$cmd" >&2
     printf '%s\n' "${term_size[1]} ${term_size[2]}"
 }
 

--- a/render-thumb-for.sh
+++ b/render-thumb-for.sh
@@ -32,7 +32,7 @@ mimeTypePDF="pdf"
 #     ?tab=readme-ov-file#get-the-terminal-size-in-pixels
 escXTERMsixelissupported=$(printf '%b' "\e[c")
 escXTERMtermsize=$(printf '%b' "\e[14;2t")
-#escXTERMtermsize=$(printf '%b' "\e[15t")
+#escXTERMcellsize=$(printf '%b' "\e[16t")
 escXTERMtermsizeTMUX=$(printf '%b' "${TMUX:+\\ePtmux;\\e}\\e[14t${TMUX:+\\e\\\\}")
 
 msgUnsupportedDisplay="image display is not supported"


### PR DESCRIPTION
related https://github.com/iambumblehead/render-thumb-for.sh/issues/26

------------------------------
this function does not work from inside vifm
```bash
# https://github.com/dylanaraps/pure-bash-bible
#  ?tab=readme-ov-file#get-the-terminal-size-in-pixels
wh_term_resolution_get () {
    # Usage: wh_term_resolution_get
    cmd=$(printf '%b' "${TMUX:+\\ePtmux;\\e}\\e[14t${TMUX:+\\e\\\\}")
    IFS=";t" read -d t -sra term_size -t 2 -p $cmd >&2
    printf '%s\n' "${term_size[1]} ${term_size[2]}"
}
```