### PR TITLE
Add iterm2 escquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  * 0.1.0 _Mar.27.2024_
    * remove [badgesize.io badge,](https://github.com/iambumblehead/thu.sh/pull/52) not working
    * use [integer timeout value](https://github.com/iambumblehead/thu.sh/pull/53) for darwin/mac read
+   * add [iterm2 esc queries](https://github.com/iambumblehead/thu.sh/pull/54)
  * 0.0.9 _Mar.16.2024_
    * simplify [multiline string definition](https://github.com/iambumblehead/thu.sh/pull/48)
  * 0.0.8 _Mar.22.2024_

--- a/thu.sh
+++ b/thu.sh
@@ -553,13 +553,13 @@ wh_term_resolution_get_tmux () {
 }
 
 wh_term_resolution_get () {
-    wh=$(wh_term_resolution_get_xterm)
-    if [[ -z "$wh" ]]; then
-        wh=$(wh_term_resolution_get_tmux)
+    whterm=$(wh_term_resolution_get_xterm)
+    if [[ -z "$whterm" ]]; then
+        whterm=$(wh_term_resolution_get_tmux)
     fi
 
-    if [[ -n "$wh" ]]; then
-        printf '%s\n' "$wh"
+    if [[ -n "$whterm" ]]; then
+        printf '%s\n' "$whterm"
     else
         fail "$msg_unknown_win_size"
     fi

--- a/thu.sh
+++ b/thu.sh
@@ -232,9 +232,9 @@ escquery_cellwh_get_iterm2 () {
     fi
 
     if [[ "${REPLY[2]}" =~ $numfl_re ]]; then
-        itermcellz=$(parse_int ${REPLY[3]})
-        itermcellw=$(($(parse_int ${REPLY[1]##*=})*${itermcellz}))
-        itermcellh=$(($(parse_int ${REPLY[2]})*${itermcellz}))
+        itermcellz=$(parse_int "${REPLY[3]}")
+        itermcellw=$(($(parse_int "${REPLY[1]##*=}")*${itermcellz}))
+        itermcellh=$(($(parse_int "${REPLY[2]}")*${itermcellz}))
 
         printf '%s\n' "${itermcellw}x${itermcellh}"
     fi


### PR DESCRIPTION
iterm seems slow as it needs to "wait" for the xterm query to finish. It seems there is no good way to "detect" iterm2 or the requirement to use iterm2-specific queries vs xterm queries