### PR TITLE
Try supporting vifm kitten icat

### DIFF
--- a/thu.sh
+++ b/thu.sh
@@ -38,6 +38,10 @@ format_type_SIXEL="SIXEL"
 format_type_KITTY="KITTY"
 format_type_NONE="NONE"
 
+color_RGBA_transp="rgba(0,0,0,0)"
+color_RGBA_black="rgba(0,0,0,1)"
+color_RGBA_cream="rgba(240,240,240,1)"
+
 # escape sequences used to query the terminal for details,
 #   https://www.mankier.com/7/foot-ctlseqs
 #   https://iterm2.com/documentation-escape-codes.html
@@ -369,7 +373,7 @@ image_to_sixel_magick () {
     export MAGICK_OCL_DEVICE=true
     if [[ -n "$is_cmd_magick" ]]; then
         magick \
-            -background "rgba(0,0,0,0)" \
+            -background "$color_RGBA_transp" \
             "$img_path" \
             -geometry "$img_wh" \
             sixel:-
@@ -377,7 +381,7 @@ image_to_sixel_magick () {
     elif [[ -n "$is_cmd_convert" ]]; then
         convert \
             -channel rgba \
-            -background "rgba(0,0,0,0)" \
+            -background "$color_RGBA_transp" \
             -geometry "$img_wh" \
             "$img_path" \
             sixel:-
@@ -862,8 +866,8 @@ thumb_create_from_font () {
     font_path=$1
     font_wh_max=$2
     font_pointsize="$(wh_pointsize_get "$2")"
-    font_bg_color="rgba(0,0,0,1)"
-    font_fg_color="rgba(240,240,240,1)"
+    font_bg_color="$color_RGBA_black"
+    font_fg_color="$color_RGBA_cream"
     font_preview_text=$(
         join $'\n' \
              "ABCDEFGHIJKLM" \
@@ -953,7 +957,7 @@ thumb_create_from_svg () {
 
     if [[ -n "$is_cmd_magick" ]]; then
         svgimg_error=$(magick \
-            -background "rgba(0,0,0,0)" \
+            -background "$color_RGBA_transp" \
             "$svgimg_path" \
             -geometry "$svgimg_target_wh" \
             "$svgimg_thumb_path" 2>&1)
@@ -961,7 +965,7 @@ thumb_create_from_svg () {
         svgimg_error=$(convert \
             -quiet \
             -channel rgba \
-            -background "rgba(0,0,0,0)" \
+            -background "$color_RGBA_transp" \
             -geometry "$svgimg_target_wh" \
             "$svgimg_path" \
             "$svgimg_thumb_path" 2>&1)

--- a/thu.sh
+++ b/thu.sh
@@ -398,12 +398,9 @@ image_to_kittenicat () {
     # or must be exactly placed AND sized
     # --place `<width>x<height>@<left>x<top>`
     # --use-window-size `cells_width,cells_height,pixels_width,pixels_height`
+    # https://github.com/kovidgoyal/kitty/discussions/7275
     if [[ -n "$is_stdout_blocked" ]]; then
-        kicat_wh_cells=$(wh_term_columnsrows_get)
-        kicat_wh_pixels=$(wh_pixels_from_cells_get "$kicat_wh_cells" "$wh_cell")
-
         kitten icat \
-               --use-window-size "${kicat_wh_cells/x/,},${kicat_wh_pixels/x/,}" \
                --place "${img_wh}@${img_tl}" \
                --align left \
                --stdin=no \

--- a/thu.sh
+++ b/thu.sh
@@ -384,6 +384,19 @@ image_to_sixel_magick () {
     fi
 }
 
+image_to_kittenicat () {
+    img_path=$1
+    img_wh=$2
+
+    # kitten does not provide a 'geometry' option
+    # so image must have been preprocessed to fit desired geometry
+    if [[ -n "$is_stdout_blocked" ]]; then
+        kitten icat --align left --transfer-mode=stream "$img_path" >/dev/tty </dev/tty
+    else
+        kitten icat --align left "$img_path"
+    fi
+}
+
 paint () {
     img_path=$1
     img_wh=$2
@@ -392,9 +405,7 @@ paint () {
         "$format_type_SIXEL")
             image_to_sixel_magick "$img_path" "$img_wh";;
         "$format_type_KITTY")
-            # kitten does not provide a 'geometry' option
-            # so image must have been preprocessed to fit desired geometry
-            kitten icat --align left "$img_path";;
+            image_to_kittenicat "$img_path" "$img_wh";;
         *)
             fail "$msg_unsupported_display, format_type: \"$3\""
     esac


### PR DESCRIPTION
<img width="874" alt="Screen Shot 2024-03-27 at 9 05 05 PM" src="https://github.com/iambumblehead/thu.sh/assets/2058705/d802069f-c9ed-4536-b1b5-79c4ece79403">

This seems to work but requires a special vifm configuration :| and requires "top" and "left" values to be declared explicitly.

thu.sh call signature is updated from `thu.sh $PATH $WIDTH $HEIGHT` to `thu.sh $PATH $TOP $LEFT $WIDTH $HEIGHT`